### PR TITLE
added possibility to include actual and expected number in string

### DIFF
--- a/jasmine-custom-message.js
+++ b/jasmine-custom-message.js
@@ -44,7 +44,12 @@
       }
     }
 
-    return message.toString();
+    message = message.toString();
+
+    message = message.replace("#{act}", data.actual);
+    message = message.replace("#{exp}", data.expected);
+
+    return message;
   };
 
   var wrapExpect = function(expect, customMessage) {


### PR DESCRIPTION
I added the possibility to include actual and expected numbers into string without having to pass a function.

So i can say:
since("object should contain #{exp} attributes, not #{act}").expect()...
without having to pass a function (making the code bigger and less readable).
