### PR TITLE
Finish implementing #4 (format string)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ describe('test', function() {
 
 ## Powerful
 
-You can use expected and actual value of the assertion in your custom message.
+You can use expected and actual value of the assertion in your custom message, by:
 
-#### Example
+  * Passing a function, and using `this.actual` and `this.expected`
+  * Passing a string, and using `#{actual}` and `#{expected}`
+
+#### Example using a function
 
 ```
 describe('test', function() {
@@ -62,6 +65,17 @@ describe('test', function() {
     since(function() {
       return this.actual + ' =/= ' + this.expected;
     }).
+    expect(3).toEqual(4); // => '3 =/= 4'
+  });
+});
+```
+
+#### Example using a string
+
+```js
+describe('test', function() {
+  it('should be ok', function() {
+    since('#{actual} =/= #{expected}').
     expect(3).toEqual(4); // => '3 =/= 4'
   });
 });

--- a/jasmine-custom-message.js
+++ b/jasmine-custom-message.js
@@ -24,7 +24,17 @@
     return types.indexOf(valType) > -1;
   };
 
+  var formatString = function(data, message) {
+    message = message.replace(/#\{actual\}/g, data.actual);
+    message = message.replace(/#\{expected\}/g, data.expected);
+    return message;
+  };
+
   var getMessage = function(data, message) {
+    if (ofType(message, 'string')) {
+      return formatString(data, message);
+    }
+
     while (! ofType(message, 'string', 'number', 'boolean')) {
       switch (true) {
         case ofType(message, 'undefined', 'null'):


### PR DESCRIPTION
@SebiTimeWaster's proposal in #4 looks very useful, so I've implemented @avrelian's [suggestions](https://github.com/avrelian/jasmine-custom-message/pull/4#issuecomment-66869601):

* I've moved the new functionality to a separate function: `formatString()`.
* I've renamed the placeholders to `#{expected}` and `#{actual}` for clarity.
* I've also used a RegExp with a global flag to perform the replacements, so that each placeholder can be used multiple times in the format string.