### PR TITLE
Fix error when assertion fails and the expected value is undefined

### DIFF
--- a/jasmine-custom-message.js
+++ b/jasmine-custom-message.js
@@ -18,7 +18,7 @@
   var isCommonJS = typeof module !== 'undefined' && typeof module.exports === 'object';
 
   var isPromise = function(val) {
-    return typeof val.then === 'function';
+    return val && typeof val.then === 'function';
   };
 
   var ofType = function(val) {

--- a/specs/common/expect-message-to-equal.js
+++ b/specs/common/expect-message-to-equal.js
@@ -10,7 +10,7 @@
   var isCommonJS = typeof module !== 'undefined' && typeof module.exports === 'object';
 
   var isPromise = function(val) {
-    return typeof val.then === 'function';
+    return val && typeof val.then === 'function';
   };
 
   var diff;

--- a/specs/common/test-jasmine-custom-message.js
+++ b/specs/common/test-jasmine-custom-message.js
@@ -40,6 +40,12 @@
 
         describe('custom failure message when it is supplied', function() {
 
+          it('and expected value is undefined', function() {
+            expectMessageToEqual("expected is undefined").
+                since('expected is undefined').
+                expect(undefined).toEqual('something');
+          });
+
           describe('with a', function() {
 
             describe('string', function() {


### PR DESCRIPTION
Just found an issue when the expected value is undefined, isPromise function was trying to check if .then is present on an undefined var